### PR TITLE
Field dummy parameters and timeout function for sweep_field mode

### DIFF
--- a/src/qcodes_contrib_drivers/drivers/OxfordInstruments/Proteox.py
+++ b/src/qcodes_contrib_drivers/drivers/OxfordInstruments/Proteox.py
@@ -7,6 +7,7 @@ import time
 import subprocess
 import platform
 import numpy as np
+from math import math.floor
 
 from qcodes.instrument import VisaInstrument
 from qcodes.parameters import MultiParameter
@@ -343,6 +344,33 @@ class oiDECS(VisaInstrument):
                 name = "Magnet_Current_Vector",
                 parameter_class=MagnetCurrentParameters,
             )
+            # qcodes can't use multiparameters as setpoint, this dummy bypasses it.  
+            self.add_parameter(
+                name='Bx',
+                unit='T',
+                label='Field X',
+                get_cmd=None,
+                set_cmd=None,
+                get_parser=None
+            )
+            self.add_parameter(
+                name='By',
+                unit='T',
+                label='Field Y',
+                get_cmd=None,
+                set_cmd=None,
+                get_parser=None
+            )
+            self.add_parameter(
+                name='Bz',
+                unit='T',
+                label='Field Z',
+                get_cmd=None,
+                set_cmd=None,
+                get_parser=None
+            )
+
+
 
             if MAGNET_HAS_SWITCH:
                 self.add_parameter(
@@ -489,6 +517,23 @@ class oiDECS(VisaInstrument):
         while status != 'Holding Not Persistent':
             status = self.Magnet_State()
             time.sleep(1)
+        print(f'Status: {self.Magnet_State()}.')
+
+    def wait_until_field_stable_timeout(self,timeout=600):
+        """VRM utility function.
+        Takes timeout in seconds, switches magnet to hold in timeout*1.1 +10s.
+        Default is 10min"""
+        start=time.time()
+        tout=timeout*1.1+10
+        status=self.Magnet_State()
+        while status != 'Holding Not Persistent':
+            status=self.Magnet_State()
+            time.sleep(1)
+            currenttime=time.time()
+            if ((currenttime-start)>tout):
+                self.set_magnet_state(0)
+                time.sleep(5)
+                status=self.Magnet_State()
         print(f'Status: {self.Magnet_State()}.')
 
     def wait_until_field_persistent(self):


### PR DESCRIPTION
Both of these addons were done as temporary solutions, but ended up being useful long term. 

1.  Dummy field parameters
QCoDeS did not support set() methods for MultiParameter class, like Magnetic_Field_Vector. 
However, for field dependencies field has to be settable. 
This is a way around this adds dummy parameters for "Bx", "By" and "Bz" with "None" methods, which allows to use them for axes in the "measurement" class and change field values manually. 

2. Frequently VRM would be stuck in "sweeping field" mode even though it has reached the target field a while ago and nothing is happening. VRM still responds to commands to switch the state to "holding non persistent" mode, for example if one relinquishes the control from qcodes script, takes control in the web interface, does this manually and then relinquishes control again. This function estimates required time to reach field target, adds a little bit and if the state is still not 'Holding non-persistent' at the set timeout it will switch the magnet to this state and exit the function. I found it useful for long overnight scans where manual control over the measurement is not possible (magnet was getting stuck a few times per ~5T sweep).
